### PR TITLE
added duckdb results provider and factory to produce providers

### DIFF
--- a/catplotlib/provider/duckdbgcbmresultsprovider.py
+++ b/catplotlib/provider/duckdbgcbmresultsprovider.py
@@ -1,0 +1,109 @@
+import os
+import logging
+import pandas as pd
+import duckdb
+from collections import OrderedDict
+from catplotlib.provider.resultsprovider import ResultsProvider
+from catplotlib.provider.units import Units
+
+class DuckDbGcbmResultsProvider(ResultsProvider):
+    '''
+    Retrieves non-spatial annual results from a DuckDb GCBM results database.
+
+    Arguments:
+    'path' -- path to duckdb GCBM results database.
+    '''
+
+    results_tables = {
+        "v_flux_indicator_aggregates": "flux_tc",
+        "v_flux_indicators"          : "flux_tc",
+        "v_pool_indicators"          : "pool_tc",
+        "v_stock_change_indicators"  : "flux_tc",
+    }
+
+    def __init__(self, paths, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._paths = [paths] if isinstance(paths, str) else paths
+        for path in self._paths:
+            if not os.path.exists(path):
+                raise IOError(f"{path} not found.")
+
+    @property
+    def path(self):
+        '''See ResultsProvider.path.'''
+        return self._paths
+
+    @property
+    def simulation_years(self):
+        '''See GcbmResultsProvider.simulation_years.'''
+        min_year = 9999
+        max_year = 0
+        for path in self._paths:
+            conn = duckdb.connect(path)
+            years = conn.execute("SELECT MIN(year), MAX(year) from v_flux_indicators WHERE year > 0").fetchone()
+            min_year = min(years[0], min_year)
+            max_year = max(years[1], max_year)
+
+        return min_year, max_year
+
+    @property
+    def simulation_area(self):
+        '''See ResultsProvider.simulation_area.'''
+        area = 0
+        for path in self._paths:
+            conn = duckdb.connect(path)
+            area += conn.execute(
+                """
+                SELECT SUM(area) FROM v_age_indicators
+                WHERE year = (SELECT MAX(year) FROM v_age_indicators)
+                """).fetchone()[0]
+
+        return area
+
+    def has_indicator(self, indicator):
+        '''See ResultsProvider.has_indicator'''
+        return self.find_indicator_table(indicator)[0] is not None
+
+    def get_annual_result(self, indicator, start_year=None, end_year=None, units=Units.Tc, **kwargs):
+        '''See GcbmResultsProvider.get_annual_result.'''
+        table, value_col = self.find_indicator_table(indicator)
+        if not table:
+            return
+
+        per_ha, units_tc, _ = units.value
+        area = self.simulation_area if per_ha else 1
+        if not start_year or not end_year:
+            start_year, end_year = self.simulation_years
+
+        df = pd.DataFrame(columns=["year", indicator])
+        for path in self._paths:
+            logging.info(f"Reading database results from {path}")
+            conn = duckdb.connect(path)
+            df = pd.concat((df, pd.read_sql_query(
+                f"""
+                SELECT
+                    years.year AS year,
+                    COALESCE(SUM(i.{value_col}), 0) AS "{indicator}"
+                FROM (SELECT DISTINCT year FROM v_age_indicators ORDER BY year) AS years
+                LEFT JOIN {table} i
+                    ON years.year = i.year
+                WHERE i.indicator = '{indicator}'
+                    AND years.year > 0
+                    AND (years.year BETWEEN {start_year} AND {end_year})
+                GROUP BY years.year
+                ORDER BY years.year
+                """, conn)
+            )).groupby("year").sum().reset_index()
+        
+        df[indicator] *= units_tc / area
+
+        return df
+
+    def find_indicator_table(self, indicator):
+        conn = duckdb.connect(self._paths[0])
+        for table, value_col in DuckDbGcbmResultsProvider.results_tables.items():
+            if conn.execute(f"SELECT 1 FROM {table} WHERE LOWER(indicator) = LOWER(?) LIMIT 1", [indicator]).fetchone():
+                return table, value_col
+
+        return None, None

--- a/catplotlib/provider/resultsproviderfactory.py
+++ b/catplotlib/provider/resultsproviderfactory.py
@@ -1,0 +1,19 @@
+from catplotlib.provider.resultsprovider import ResultsProvider
+from catplotlib.provider.sqlitegcbmresultsprovider import SqliteGcbmResultsProvider
+from catplotlib.provider.duckdbgcbmresultsprovider import DuckDbGcbmResultsProvider
+
+class ResultsProviderFactory:
+
+    def get_results_provider(self, paths, *args, **kwargs) -> ResultsProvider:
+        
+        if not isinstance(paths, list):
+            paths = [paths]
+
+        if all([path.endswith('.db') for path in paths]):
+            return SqliteGcbmResultsProvider(paths, *args, **kwargs)
+        elif all([path.endswith('.duckdb') for path in paths]):
+            return DuckDbGcbmResultsProvider(paths, *args, **kwargs)
+        else:
+            raise NotImplementedError(f"Ensure all Database path extensions are 'db' for sqlite or 'duckdb' for duckdb: {paths}")
+
+

--- a/catplotlib/reporting/provider/stylingresultsprovider.py
+++ b/catplotlib/reporting/provider/stylingresultsprovider.py
@@ -1,5 +1,5 @@
 from catplotlib.provider.resultsprovider import ResultsProvider
-from catplotlib.provider.sqlitegcbmresultsprovider import SqliteGcbmResultsProvider
+from catplotlib.provider.resultsproviderfactory import ResultsProviderFactory
 from catplotlib.provider.units import Units
 from catplotlib.reporting.style.stylemanager import StyleManager
 
@@ -20,7 +20,7 @@ class StylingResultsProvider(ResultsProvider):
         self._style_manager = style_manager or StyleManager()
 
         if not provider:
-            provider = SqliteGcbmResultsProvider(path, *args, **kwargs)
+            provider = ResultsProviderFactory().get_results_provider(path, *args, **kwargs)
 
         self._provider = provider
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         "sqlalchemy", "psutil",
         "numpy", "seaborn", "imageio", "imageio-ffmpeg",
         "pillow", "geopy", "utm", "jupyter-book", "sphinxcontrib-bibtex",
-        "aenum", "pyepsg", "pyppeteer", "plotly",
+        "aenum", "pyepsg", "pyppeteer", "plotly", 'duckdb',
         "pysal<=1.15.0; python_version=='3.7'", "pysal; python_version>'3.7'",
         "mojadata>=4.0.6",
         "shapely>=1.8.1, <=1.8.2", # cartopy (any ver) requires this version of shapely

--- a/test/provider/factory_test.py
+++ b/test/provider/factory_test.py
@@ -1,0 +1,44 @@
+import unittest
+from tempfile import TemporaryDirectory
+from pathlib import Path
+from catplotlib.provider.resultsproviderfactory import ResultsProviderFactory
+from catplotlib.provider.sqlitegcbmresultsprovider import SqliteGcbmResultsProvider
+from catplotlib.provider.duckdbgcbmresultsprovider import DuckDbGcbmResultsProvider
+
+class ResultsProviderFactoryTest(unittest.TestCase):
+
+    def test_non_list_input(self):
+        with TemporaryDirectory() as temp_dir:
+            db = Path(temp_dir, 'test.db')
+            db.touch()
+            provider = ResultsProviderFactory().get_results_provider(str(db))
+            assert isinstance(provider, SqliteGcbmResultsProvider)
+    
+    def test_sqlite(self):
+        with TemporaryDirectory() as temp_dir:
+            db = Path(temp_dir, 'test.db')
+            db.touch()
+            provider = ResultsProviderFactory().get_results_provider([str(db)])
+            assert isinstance(provider, SqliteGcbmResultsProvider)
+
+    def test_duckdb(self):
+        with TemporaryDirectory() as temp_dir:
+            db = Path(temp_dir, 'test.duckdb')
+            db.touch()
+            provider = ResultsProviderFactory().get_results_provider([str(db)])
+            assert isinstance(provider, DuckDbGcbmResultsProvider)
+            assert not isinstance(provider, SqliteGcbmResultsProvider)
+
+    def test_mismatch(self):
+       with TemporaryDirectory() as temp_dir:
+            db_sqlite = Path(temp_dir, 'test.db')
+            db_duckdb = Path(temp_dir, 'test.duckdb')
+            db_sqlite.touch()
+            db_duckdb.touch()
+            try:
+                provider = ResultsProviderFactory().get_results_provider([str(db_sqlite), str(db_duckdb)])
+            except Exception as e:
+                assert isinstance(e, NotImplementedError) 
+
+    
+        


### PR DESCRIPTION
Added duckdb results provider to support post_gcbm_batch scripts use of duckdb for gcbm databases. 

duckdb results provider is copied from sqlite results provider with very little modification. It works for the post_gcbm_batch scripts so I've left it as is for now but there could be issues with pandas functions that use the connection object. 

In the future this could be improved by using sqlalchemy connections inside a generic results provider and allowing the factory to inject the connection. 